### PR TITLE
enforce order with an ordereddict

### DIFF
--- a/tgf/scripts/cli.py
+++ b/tgf/scripts/cli.py
@@ -1,10 +1,13 @@
 import click
 import cligj
 import json
+from collections import OrderedDict
+
 
 @click.command('tgf')
 @cligj.features_in_arg
 def cli(features):
     click.echo(json.dumps(
-        {'type': 'FeatureCollection',
-         'features': list(features)}))
+        OrderedDict([
+            ('type', 'FeatureCollection'),
+            ('features', list(features))])))


### PR DESCRIPTION
json dumping a dict isn't guaranteed to keep the original order (it can change in different python versions or different implementations) so we need to go back to the `ordereddict` to enforce it.